### PR TITLE
fix: initialize vercel analytics helper properly

### DIFF
--- a/components/Analytics.tsx
+++ b/components/Analytics.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { useEffect } from 'react';
-import Analytics from '@vercel/analytics';
+import { inject } from '@vercel/analytics';
 
 export function AnalyticsProvider() {
   useEffect(() => {
-    Analytics.inject();
+    inject();
   }, []);
 
   return null;


### PR DESCRIPTION
## Summary
- swap the default import for the named `inject` helper from `@vercel/analytics`
- invoke the helper inside the analytics provider effect so the SDK initializes without runtime errors

## Testing
- npm run lint
- npm run dev (spot-checked console output via Playwright)


------
https://chatgpt.com/codex/tasks/task_e_68cc336668948320847d3ae8403c228c