### PR TITLE
Allow configuring OpenRouter data policy header

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ AI-assisted triage workflow for large BibTeX exports. Upload your Zotero export,
 
 ### API Keys
 - **OpenRouter**: generate a key at [openrouter.ai/keys](https://openrouter.ai/keys). Ensure your privacy settings allow public models and the GPT-OSS-120B endpoint.
+- **Data policy overrides**: The credentials panel lets you keep the request on your account's default privacy mode (no header) or send a custom `X-OpenRouter-Data-Policy` value such as `permissive` for individual runs.
 - **Google Gemini**: create a key via [Google AI Studio](https://aistudio.google.com/app/apikey) or Cloud Generative AI.
 
 Keys are stored only in your browser (localStorage) and sent with each triage request when you click “Save locally.”

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,6 +25,7 @@ export default function HomePage() {
   const [isTriageRunning, setIsTriageRunning] = useState(false);
   const [provider, setProvider] = useState<Provider>('openrouter');
   const [openRouterKey, setOpenRouterKey] = useState('');
+  const [openRouterDataPolicy, setOpenRouterDataPolicy] = useState('');
   const [geminiKey, setGeminiKey] = useState('');
   const [reasoningEffort, setReasoningEffort] = useState<ReasoningEffort>('high');
   const [warnings, setWarnings] = useState<string[]>([]);
@@ -116,7 +117,10 @@ export default function HomePage() {
         };
         if (provider === 'openrouter') {
           headers['X-OpenRouter-Key'] = openRouterKey.trim();
-          headers['X-OpenRouter-Data-Policy'] = 'permissive';
+          const dataPolicyHeader = openRouterDataPolicy.trim();
+          if (dataPolicyHeader) {
+            headers['X-OpenRouter-Data-Policy'] = dataPolicyHeader;
+          }
         } else {
           headers['X-Gemini-Key'] = geminiKey.trim();
         }
@@ -183,6 +187,8 @@ export default function HomePage() {
         onProviderChange={setProvider}
         openRouterKey={openRouterKey}
         onOpenRouterKeyChange={setOpenRouterKey}
+        openRouterDataPolicy={openRouterDataPolicy}
+        onOpenRouterDataPolicyChange={setOpenRouterDataPolicy}
         geminiKey={geminiKey}
         onGeminiKeyChange={setGeminiKey}
         reasoningEffort={reasoningEffort}


### PR DESCRIPTION
## Summary
- add controls to the credentials form so OpenRouter runs can use the account default privacy mode or a custom X-OpenRouter-Data-Policy value
- only forward the data policy header from the triage API when the client explicitly supplies one and document the behavior in the README

## Testing
- npm run lint
- npm run test
- manual OpenRouter triage run with strict privacy (not run – OpenRouter key unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cc3368ee208320b83d667e7a55208c