### PR TITLE
feat: add support for OpenRouter Grok-4 fast model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Literature Screening Assistant
 
-AI-assisted triage workflow for large BibTeX exports. Upload your Zotero export, configure inclusion/exclusion criteria, and run sequential screening with OpenRouter GPT-OSS-120B or Google Gemini 2.5 Pro.
+AI-assisted triage workflow for large BibTeX exports. Upload your Zotero export, configure inclusion/exclusion criteria, and run sequential screening with OpenRouter models (GPT-OSS-120B or xAI Grok-4 fast/free) or Google Gemini 2.5 Pro.
 
 ## Features
 - **Sequential record triage** with live progress, warnings, and exportable decisions (CSV, JSON, annotated BibTeX).
 - **Flexible criteria editor**: paste human-readable inclusion/exclusion rules; deterministic heuristics backstop LLM failures.
-- **Provider selection & reasoning control**: choose OpenRouter or Gemini, set reasoning effort (none/low/medium/high) for GPT-OSS-120B, and store keys locally.
+- **Provider selection & reasoning control**: choose OpenRouter or Gemini, pick an OpenRouter model, adjust reasoning effort where supported, and store keys locally.
 - **Traceable outputs**: every record captures status, confidence, matched rules, model, and rationale.
 
 ## Getting Started
@@ -14,7 +14,7 @@ AI-assisted triage workflow for large BibTeX exports. Upload your Zotero export,
 3. Open `http://localhost:3000` and upload a BibTeX export (the repository ships with `Exported Items.bib` for testing).
 
 ### API Keys
-- **OpenRouter**: generate a key at [openrouter.ai/keys](https://openrouter.ai/keys). Ensure your privacy settings allow public models and the GPT-OSS-120B endpoint.
+- **OpenRouter**: generate a key at [openrouter.ai/keys](https://openrouter.ai/keys). Ensure your privacy settings allow public models and the GPT-OSS-120B or xAI Grok-4 fast endpoints.
 - **Data policy overrides**: The credentials panel lets you keep the request on your account's default privacy mode (no header) or send a custom `X-OpenRouter-Data-Policy` value such as `permissive` for individual runs.
 - **Google Gemini**: create a key via [Google AI Studio](https://aistudio.google.com/app/apikey) or Cloud Generative AI.
 
@@ -23,7 +23,7 @@ Keys are stored only in your browser (localStorage) and sent with each triage re
 ## Usage Flow
 1. Upload BibTeX → records load into memory; you can inspect counts immediately.
 2. Configure provider and API key.
-   - OpenRouter users may adjust reasoning effort (higher = better deliberation, more latency/tokens).
+   - OpenRouter users can select GPT-OSS-120B or xAI Grok-4 fast (free). Reasoning effort is available only for GPT-OSS-120B.
 3. Paste or tweak inclusion/exclusion criteria; deterministic heuristics update automatically.
 4. Click **Start LLM triage pass** to process entries sequentially. Progress updates one record at a time.
 5. Review results, warnings, and export decisions as needed.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,6 +12,7 @@ import { parseBibtex } from '@/lib/bibtexParser';
 import { buildCriteriaFromText, getDefaultCriteriaText } from '@/lib/criteria';
 import { summarizeDecisions } from '@/lib/triage';
 import type { BibEntry, TriageDecision, TriageSummary } from '@/lib/types';
+import { DEFAULT_OPENROUTER_MODEL_ID, type OpenRouterModelId } from '@/lib/openrouter';
 
 export default function HomePage() {
   const [isLoading, setIsLoading] = useState(false);
@@ -25,6 +26,7 @@ export default function HomePage() {
   const [isTriageRunning, setIsTriageRunning] = useState(false);
   const [provider, setProvider] = useState<Provider>('openrouter');
   const [openRouterKey, setOpenRouterKey] = useState('');
+  const [openRouterModel, setOpenRouterModel] = useState<OpenRouterModelId>(DEFAULT_OPENROUTER_MODEL_ID);
   const [openRouterDataPolicy, setOpenRouterDataPolicy] = useState('');
   const [geminiKey, setGeminiKey] = useState('');
   const [reasoningEffort, setReasoningEffort] = useState<ReasoningEffort>('high');
@@ -136,7 +138,9 @@ export default function HomePage() {
             },
             heuristics,
             provider,
-            reasoning: provider === 'openrouter' ? reasoningEffort : undefined,
+            ...(provider === 'openrouter'
+              ? { reasoning: reasoningEffort, model: openRouterModel }
+              : {}),
           }),
         });
 
@@ -187,6 +191,8 @@ export default function HomePage() {
         onProviderChange={setProvider}
         openRouterKey={openRouterKey}
         onOpenRouterKeyChange={setOpenRouterKey}
+        openRouterModel={openRouterModel}
+        onOpenRouterModelChange={setOpenRouterModel}
         openRouterDataPolicy={openRouterDataPolicy}
         onOpenRouterDataPolicyChange={setOpenRouterDataPolicy}
         geminiKey={geminiKey}

--- a/lib/openrouter.ts
+++ b/lib/openrouter.ts
@@ -1,0 +1,38 @@
+export const OPENROUTER_MODELS = [
+  {
+    id: 'openai/gpt-oss-120b',
+    label: 'OpenAI GPT-OSS-120B',
+    supportsReasoning: true,
+    promptCharacterLimit: 12000,
+    maxTokens: 4096,
+  },
+  {
+    id: 'x-ai/grok-4-fast:free',
+    label: 'xAI Grok-4 (fast, free)',
+    supportsReasoning: false,
+    promptCharacterLimit: 8000,
+    maxTokens: 2048,
+  },
+] as const;
+
+export type OpenRouterModelConfig = (typeof OPENROUTER_MODELS)[number];
+export type OpenRouterModelId = OpenRouterModelConfig['id'];
+
+export const OPENROUTER_MODEL_IDS = OPENROUTER_MODELS.map((model) => model.id) as [
+  OpenRouterModelId,
+  ...OpenRouterModelId[],
+];
+
+export const DEFAULT_OPENROUTER_MODEL_ID: OpenRouterModelId = OPENROUTER_MODELS[0].id;
+
+export function isOpenRouterModelId(value: string): value is OpenRouterModelId {
+  return OPENROUTER_MODEL_IDS.includes(value as OpenRouterModelId);
+}
+
+export function getOpenRouterModel(id: string): OpenRouterModelConfig {
+  return OPENROUTER_MODELS.find((model) => model.id === id) ?? OPENROUTER_MODELS[0];
+}
+
+export function formatOpenRouterLabel(model: OpenRouterModelConfig) {
+  return `OpenRouter — ${model.label}`;
+}


### PR DESCRIPTION
## Summary
- add an OpenRouter model catalog and expose Grok-4 fast (free) in the credentials form
- wire the selected model through the triage API, guarding reasoning support and payload limits per model
- document the new OpenRouter option and reasoning caveats in the README

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d01961cd788320acdee048d3a3ca22