### PR TITLE
feat: enable Grok-4 fast reasoning options

### DIFF
--- a/app/api/triage/payloads.ts
+++ b/app/api/triage/payloads.ts
@@ -1,0 +1,162 @@
+import type { CriteriaTextInput } from '@/lib/criteria';
+import type { triageRecord } from '@/lib/triage';
+import type { OpenRouterModelConfig, OpenRouterReasoningEffort } from '@/lib/openrouter';
+
+const GEMINI_THINKING_BUDGET = 4096;
+
+type DeterministicResult = ReturnType<typeof triageRecord>;
+
+type Entry = {
+  type: string;
+  key: string;
+  fields: Record<string, string>;
+};
+
+export interface OpenRouterRequest {
+  model: OpenRouterModelConfig['id'];
+  messages: Array<{ role: 'system' | 'user' | 'assistant'; content: string }>;
+  max_tokens: number;
+  temperature: number;
+  reasoning?: {
+    enabled: true;
+    effort: Exclude<OpenRouterReasoningEffort, 'none'>;
+  };
+}
+
+export interface GeminiRequest {
+  systemInstruction?: {
+    parts: Array<{ text?: string }>;
+  };
+  contents: Array<{
+    role: string;
+    parts: Array<{ text?: string }>;
+  }>;
+  generationConfig: {
+    temperature: number;
+    maxOutputTokens: number;
+    responseMimeType?: string;
+  };
+  thinkingConfig?: {
+    thinkingBudget?: number;
+  };
+}
+
+export function buildOpenRouterPayload(
+  entry: Entry,
+  instructions: CriteriaTextInput,
+  deterministic: DeterministicResult,
+  effort: OpenRouterReasoningEffort,
+  model: OpenRouterModelConfig,
+): OpenRouterRequest {
+  const userPrompt = buildUserPrompt(entry, instructions, deterministic, model.promptCharacterLimit);
+
+  const messages: OpenRouterRequest['messages'] = [
+    {
+      role: 'system',
+      content:
+        'You are a rigorous systematic review screening assistant. Always return valid JSON with keys: status, confidence, rationale, criteria_refs, model.',
+    },
+    {
+      role: 'user',
+      content: JSON.stringify(userPrompt),
+    },
+  ];
+
+  const request: OpenRouterRequest = {
+    model: model.id,
+    messages,
+    max_tokens: model.maxTokens,
+    temperature: 0,
+  };
+
+  if (effort !== 'none' && model.supportsReasoning) {
+    request.reasoning = { enabled: true, effort };
+  }
+
+  return request;
+}
+
+export function buildGeminiPayload(
+  entry: Entry,
+  instructions: CriteriaTextInput,
+  deterministic: DeterministicResult,
+  simpleMode: boolean,
+): GeminiRequest {
+  const limit = simpleMode ? 2500 : 4000;
+  const userPrompt = buildUserPrompt(entry, instructions, deterministic, limit);
+
+  const request: GeminiRequest = {
+    contents: [
+      {
+        role: 'user',
+        parts: [{ text: JSON.stringify(userPrompt) }],
+      },
+    ],
+    generationConfig: {
+      temperature: 0,
+      maxOutputTokens: simpleMode ? 1024 : 2048,
+    },
+  };
+
+  if (!simpleMode) {
+    request.systemInstruction = {
+      parts: [{ text: 'You are a systematic review screening assistant. Respond with strict JSON only.' }],
+    };
+    request.generationConfig.responseMimeType = 'application/json';
+    request.thinkingConfig = {
+      thinkingBudget: Math.min(GEMINI_THINKING_BUDGET, 2048),
+    };
+  }
+
+  return request;
+}
+
+function buildUserPrompt(
+  entry: Entry,
+  instructions: CriteriaTextInput,
+  deterministic: DeterministicResult,
+  limit: number,
+) {
+  const record = extractRecordFields(entry);
+  const trimmedInstructions = {
+    inclusion: truncate(instructions.inclusion, limit),
+    exclusion: truncate(instructions.exclusion, limit),
+  } satisfies CriteriaTextInput;
+
+  return {
+    record,
+    instructions: trimmedInstructions,
+    deterministic,
+    expected_json: {
+      status: 'Include | Exclude | Maybe',
+      confidence: '0-1 number',
+      rationale: '50-150 word explanation citing criteria IDs',
+      criteria_refs: 'array of criteria IDs referenced',
+    },
+  };
+}
+
+function extractRecordFields(entry: Entry) {
+  const keywords = (entry.fields.keywords || '')
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+
+  return {
+    key: entry.key,
+    type: entry.type,
+    title: entry.fields.title || '',
+    abstract: entry.fields.abstract || '',
+    keywords,
+    year: entry.fields.year || '',
+    notes: entry.fields.note || entry.fields.notes || '',
+    venue: entry.fields.journal || entry.fields.booktitle || '',
+  };
+}
+
+function truncate(text: string, limit: number) {
+  if (text.length <= limit) {
+    return text;
+  }
+  return `${text.slice(0, limit - 3)}...`;
+}

--- a/app/api/triage/route.ts
+++ b/app/api/triage/route.ts
@@ -11,10 +11,11 @@ import {
   getOpenRouterModel,
   type OpenRouterModelConfig,
   type OpenRouterModelId,
+  type OpenRouterReasoningEffort,
 } from '@/lib/openrouter';
 
 type Provider = 'openrouter' | 'gemini';
-type ReasoningEffort = 'none' | 'low' | 'medium' | 'high';
+type ReasoningEffort = OpenRouterReasoningEffort;
 
 const fieldMapSchema = z.record(z.string());
 
@@ -48,7 +49,7 @@ const baseRequestSchema = z.object({
 
 const openRouterRequestSchema = baseRequestSchema.extend({
   provider: z.literal('openrouter'),
-  reasoning: z.enum(['none', 'low', 'medium', 'high']).optional(),
+  reasoning: z.enum(['none', 'minimal', 'low', 'medium', 'high']).optional(),
   model: z.enum(OPENROUTER_MODEL_IDS).default(DEFAULT_OPENROUTER_MODEL_ID),
 });
 
@@ -301,7 +302,7 @@ function buildOpenRouterPayload(
   };
 
   if (effort !== 'none' && model.supportsReasoning) {
-    request.reasoning = { effort };
+    request.reasoning = { enabled: true, effort };
   }
 
   return request;
@@ -558,7 +559,8 @@ interface OpenRouterRequest {
   max_tokens: number;
   temperature: number;
   reasoning?: {
-    effort: 'low' | 'medium' | 'high';
+    enabled: true;
+    effort: 'minimal' | 'low' | 'medium' | 'high';
   };
 }
 
@@ -597,3 +599,5 @@ interface GeminiResponse {
     output?: string;
   }>;
 }
+
+export { buildOpenRouterPayload };

--- a/app/api/triage/route.ts
+++ b/app/api/triage/route.ts
@@ -10,9 +10,9 @@ import {
   formatOpenRouterLabel,
   getOpenRouterModel,
   type OpenRouterModelConfig,
-  type OpenRouterModelId,
   type OpenRouterReasoningEffort,
 } from '@/lib/openrouter';
+import { buildGeminiPayload, buildOpenRouterPayload } from './payloads';
 
 type Provider = 'openrouter' | 'gemini';
 type ReasoningEffort = OpenRouterReasoningEffort;
@@ -61,7 +61,6 @@ const requestSchema = z.discriminatedUnion('provider', [openRouterRequestSchema,
 
 const MAX_ATTEMPTS = 2;
 const GEMINI_MODEL = 'gemini-2.5-pro';
-const GEMINI_THINKING_BUDGET = 4096;
 
 export const runtime = 'nodejs';
 
@@ -273,119 +272,6 @@ async function runGeminiPass({
   return { decision: null, warning: lastError ? `Gemini: ${lastError}` : 'Gemini failed without details.' };
 }
 
-function buildOpenRouterPayload(
-  entry: z.infer<typeof entrySchema>,
-  instructions: CriteriaTextInput,
-  deterministic: ReturnType<typeof triageRecord>,
-  effort: ReasoningEffort,
-  model: OpenRouterModelConfig,
-) {
-  const userPrompt = buildUserPrompt(entry, instructions, deterministic, model.promptCharacterLimit);
-
-  const messages: OpenRouterRequest['messages'] = [
-    {
-      role: 'system',
-      content:
-        'You are a rigorous systematic review screening assistant. Always return valid JSON with keys: status, confidence, rationale, criteria_refs, model.',
-    },
-    {
-      role: 'user',
-      content: JSON.stringify(userPrompt),
-    },
-  ];
-
-  const request: OpenRouterRequest = {
-    model: model.id,
-    messages,
-    max_tokens: model.maxTokens,
-    temperature: 0,
-  };
-
-  if (effort !== 'none' && model.supportsReasoning) {
-    request.reasoning = { enabled: true, effort };
-  }
-
-  return request;
-}
-
-function buildGeminiPayload(
-  entry: z.infer<typeof entrySchema>,
-  instructions: CriteriaTextInput,
-  deterministic: ReturnType<typeof triageRecord>,
-  simpleMode: boolean,
-) {
-  const limit = simpleMode ? 2500 : 4000;
-  const userPrompt = buildUserPrompt(entry, instructions, deterministic, limit);
-
-  const request: GeminiRequest = {
-    contents: [
-      {
-        role: 'user',
-        parts: [{ text: JSON.stringify(userPrompt) }],
-      },
-    ],
-    generationConfig: {
-      temperature: 0,
-      maxOutputTokens: simpleMode ? 1024 : 2048,
-    },
-  };
-
-  if (!simpleMode) {
-    request.systemInstruction = {
-      parts: [{ text: 'You are a systematic review screening assistant. Respond with strict JSON only.' }],
-    };
-    request.generationConfig.responseMimeType = 'application/json';
-    request.thinkingConfig = {
-      thinkingBudget: Math.min(GEMINI_THINKING_BUDGET, 2048),
-    };
-  }
-
-  return request;
-}
-
-function buildUserPrompt(
-  entry: z.infer<typeof entrySchema>,
-  instructions: CriteriaTextInput,
-  deterministic: ReturnType<typeof triageRecord>,
-  limit: number,
-) {
-  const record = extractRecordFields(entry);
-  const trimmedInstructions = {
-    inclusion: truncate(instructions.inclusion, limit),
-    exclusion: truncate(instructions.exclusion, limit),
-  } satisfies CriteriaTextInput;
-
-  return {
-    record,
-    instructions: trimmedInstructions,
-    deterministic,
-    expected_json: {
-      status: 'Include | Exclude | Maybe',
-      confidence: '0-1 number',
-      rationale: '50-150 word explanation citing criteria IDs',
-      criteria_refs: 'array of criteria IDs referenced',
-    },
-  };
-}
-
-function extractRecordFields(entry: z.infer<typeof entrySchema>) {
-  const keywords = (entry.fields.keywords || '')
-    .split(',')
-    .map((item) => item.trim())
-    .filter(Boolean);
-
-  return {
-    key: entry.key,
-    type: entry.type,
-    title: entry.fields.title || '',
-    abstract: entry.fields.abstract || '',
-    keywords,
-    year: entry.fields.year || '',
-    notes: entry.fields.note || entry.fields.notes || '',
-    venue: entry.fields.journal || entry.fields.booktitle || '',
-  };
-}
-
 function buildDecision(
   entry: z.infer<typeof entrySchema>,
   deterministic: ReturnType<typeof triageRecord>,
@@ -447,13 +333,6 @@ function normalizeStatus(status?: string) {
 
 function clamp(value: number, min: number, max: number) {
   return Math.min(Math.max(value, min), max);
-}
-
-function truncate(text: string, limit: number) {
-  if (text.length <= limit) {
-    return text;
-  }
-  return `${text.slice(0, limit - 3)}...`;
 }
 
 function safeParseLLMJson(raw: string) {
@@ -553,17 +432,6 @@ function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-interface OpenRouterRequest {
-  model: OpenRouterModelId;
-  messages: Array<{ role: 'system' | 'user' | 'assistant'; content: string }>;
-  max_tokens: number;
-  temperature: number;
-  reasoning?: {
-    enabled: true;
-    effort: 'minimal' | 'low' | 'medium' | 'high';
-  };
-}
-
 interface OpenRouterResponse {
   choices: Array<{
     message?: {
@@ -571,24 +439,6 @@ interface OpenRouterResponse {
     };
     content?: string;
   }>;
-}
-
-interface GeminiRequest {
-  systemInstruction?: {
-    parts: Array<{ text?: string }>;
-  };
-  contents: Array<{
-    role: string;
-    parts: Array<{ text?: string }>;
-  }>;
-  generationConfig: {
-    temperature: number;
-    maxOutputTokens: number;
-    responseMimeType?: string;
-  };
-  thinkingConfig?: {
-    thinkingBudget?: number;
-  };
 }
 
 interface GeminiResponse {
@@ -599,5 +449,3 @@ interface GeminiResponse {
     output?: string;
   }>;
 }
-
-export { buildOpenRouterPayload };

--- a/components/ModelCredentialsForm.tsx
+++ b/components/ModelCredentialsForm.tsx
@@ -3,14 +3,14 @@
 import { useEffect, useMemo, useState } from 'react';
 import {
   OPENROUTER_MODELS,
-  formatOpenRouterLabel,
   getOpenRouterModel,
   isOpenRouterModelId,
   type OpenRouterModelId,
+  type OpenRouterReasoningEffort,
 } from '@/lib/openrouter';
 
 type Provider = 'openrouter' | 'gemini';
-type ReasoningEffort = 'none' | 'low' | 'medium' | 'high';
+type ReasoningEffort = OpenRouterReasoningEffort;
 
 interface ModelCredentialsFormProps {
   provider: Provider;
@@ -132,7 +132,7 @@ export function ModelCredentialsForm({
   };
 
   const selectedModel = useMemo(() => getOpenRouterModel(openRouterModel), [openRouterModel]);
-  const providerLabel = useMemo(() => formatOpenRouterLabel(selectedModel), [selectedModel]);
+  const providerLabel = 'OpenRouter';
   const reasoningDisabled = disabled || !selectedModel.supportsReasoning;
   const modelDetails = useMemo(() => {
     const capability = selectedModel.supportsReasoning ? 'Supports reasoning' : 'No reasoning mode';
@@ -222,6 +222,7 @@ export function ModelCredentialsForm({
                 className="mt-2 w-full rounded border border-slate-300 px-3 py-2 text-sm disabled:cursor-not-allowed disabled:bg-slate-50 disabled:text-slate-500"
               >
                 <option value="none">None</option>
+                <option value="minimal">Minimal</option>
                 <option value="low">Low</option>
                 <option value="medium">Medium</option>
                 <option value="high">High</option>

--- a/lib/openrouter.ts
+++ b/lib/openrouter.ts
@@ -1,16 +1,25 @@
+export type OpenRouterReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high';
+
 export const OPENROUTER_MODELS = [
   {
     id: 'x-ai/grok-4-fast:free',
     label: 'xAI Grok-4 (fast, free)',
-    supportsReasoning: false,
-    promptCharacterLimit: 8000,
-    maxTokens: 2048,
+    supportsReasoning: true,
+    promptCharacterLimit: 2_000_000,
+    maxTokens: 8192,
+  },
+  {
+    id: 'x-ai/grok-4-fast',
+    label: 'xAI Grok-4 (fast)',
+    supportsReasoning: true,
+    promptCharacterLimit: 2_000_000,
+    maxTokens: 8192,
   },
   {
     id: 'openai/gpt-oss-120b',
     label: 'OpenAI GPT-OSS-120B',
     supportsReasoning: true,
-    promptCharacterLimit: 12000,
+    promptCharacterLimit: 12_000,
     maxTokens: 4096,
   },
 ] as const;

--- a/tests/app/api/triage/route.spec.ts
+++ b/tests/app/api/triage/route.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildOpenRouterPayload } from '../../../../app/api/triage/route';
+import { buildOpenRouterPayload } from '../../../../app/api/triage/payloads';
 import { getOpenRouterModel } from '@/lib/openrouter';
 import type { CriteriaTextInput } from '@/lib/criteria';
 import type { RuleMatch } from '@/lib/types';

--- a/tests/app/api/triage/route.spec.ts
+++ b/tests/app/api/triage/route.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { buildOpenRouterPayload } from '../../../../app/api/triage/route';
+import { getOpenRouterModel } from '@/lib/openrouter';
+import type { CriteriaTextInput } from '@/lib/criteria';
+import type { RuleMatch } from '@/lib/types';
+
+type DeterministicResult = {
+  status: 'Include' | 'Exclude' | 'Maybe';
+  confidence: number;
+  inclusionMatches: RuleMatch[];
+  exclusionMatches: RuleMatch[];
+};
+
+const entry = {
+  type: 'article',
+  key: 'smith2024',
+  fields: {
+    title: 'Sample Title',
+    abstract: 'Example abstract discussing language practice.',
+    keywords: 'practice, english',
+    year: '2024',
+  },
+};
+
+const instructions: CriteriaTextInput = {
+  inclusion: 'Adults only. Speaking performance target.',
+  exclusion: 'No behavioral mechanism.',
+};
+
+const deterministic: DeterministicResult = {
+  status: 'Include',
+  confidence: 0.75,
+  inclusionMatches: [],
+  exclusionMatches: [],
+};
+
+describe('buildOpenRouterPayload', () => {
+  it('enables reasoning when effort is provided', () => {
+    const model = getOpenRouterModel('x-ai/grok-4-fast:free');
+    const payload = buildOpenRouterPayload(entry, instructions, deterministic, 'minimal', model);
+
+    expect(payload.reasoning).toEqual({ enabled: true, effort: 'minimal' });
+  });
+
+  it('omits reasoning when effort is none', () => {
+    const model = getOpenRouterModel('x-ai/grok-4-fast:free');
+    const payload = buildOpenRouterPayload(entry, instructions, deterministic, 'none', model);
+
+    expect(payload.reasoning).toBeUndefined();
+  });
+});

--- a/tests/lib/openrouter.spec.ts
+++ b/tests/lib/openrouter.spec.ts
@@ -11,7 +11,15 @@ describe('openrouter configuration', () => {
   it('exposes grok-4 fast free as the default OpenRouter model', () => {
     const config = getOpenRouterModel(DEFAULT_OPENROUTER_MODEL_ID);
     expect(config.id).toBe('x-ai/grok-4-fast:free');
-    expect(config.supportsReasoning).toBe(false);
+    expect(config.supportsReasoning).toBe(true);
+    expect(config.promptCharacterLimit).toBe(2_000_000);
+    expect(config.maxTokens).toBe(8192);
+  });
+
+  it('includes the paid grok-4 fast tier with reasoning support', () => {
+    const paidTier = OPENROUTER_MODELS.find((model) => model.id === 'x-ai/grok-4-fast');
+    expect(paidTier).toBeDefined();
+    expect(paidTier?.supportsReasoning).toBe(true);
   });
 
   it('falls back to the default model for unknown identifiers', () => {


### PR DESCRIPTION
## Summary
- mark Grok-4 fast (free and paid) as reasoning-capable and expose the shared model metadata updates
- allow choosing the new "Minimal" reasoning effort while showing a simplified OpenRouter provider label
- send OpenRouter reasoning flags when enabled and add targeted unit tests for the configuration and payload builder

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d0c8e97e2083208524d165b74efd26